### PR TITLE
Add gson dependency to pom.xml

### DIFF
--- a/DownloadSendsafely/pom.xml
+++ b/DownloadSendsafely/pom.xml
@@ -37,6 +37,11 @@
       <artifactId>commons-io</artifactId>
       <version>2.6</version>
     </dependency>
+     <dependency>
+       <groupId>com.google.code.gson</groupId>
+       <artifactId>gson</artifactId>
+       <version>2.8.6</version>
+     </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
DownloadSendsafely has a dependency that was overlooked.  
Add gson dependency to pom.xml