### PR TITLE
Adding python utility for ZD ticket management on local machine

### DIFF
--- a/Support Automation/ZendeskTicketUtil/README.md
+++ b/Support Automation/ZendeskTicketUtil/README.md
@@ -2,7 +2,14 @@ This utility will delete directories pertaining to ZenDesk tickets that are no l
 
 Use `python3 zd_util.py -h` for usage instructions.
 
+This script expects that ticket directory you specify contains top-level directory names that are ticket numbers.
+For example: /users/me/tickets/
+			       |-> 12345
+			       |-> 23456
+			       |-> 19863
+
 Prerequisites:
+
 	1. Generate an API token in ZenDesk to use for authentication purposes. This can be found under Admin > API >
 	   Add API Token in the ZenDesk support portal.
 	2. You must create a `creds.json` file in the directory you plan to execute this from. The file should contain a

--- a/Support Automation/ZendeskTicketUtil/README.md
+++ b/Support Automation/ZendeskTicketUtil/README.md
@@ -1,0 +1,12 @@
+This utility will delete directories pertaining to ZenDesk tickets that are no longer open.
+
+Use `python3 zd_util.py -h` for usage instructions.
+
+Prerequisites:
+	1. Generate an API token in ZenDesk to use for authentication purposes. This can be found under Admin > API >
+	   Add API Token in the ZenDesk support portal.
+	2. You must create a `creds.json` file in the directory you plan to execute this from. The file should contain a
+	   JSON block with the following structure:
+		{ "email": "<your-email-address>", "token": "<zendesk-api-token>", "subdomain": "streamsets" }
+	3. Install the Zenpy dependency for your version of Python:
+		pip install Zenpy

--- a/Support Automation/ZendeskTicketUtil/README.md
+++ b/Support Automation/ZendeskTicketUtil/README.md
@@ -3,10 +3,14 @@ This utility will delete directories pertaining to ZenDesk tickets that are no l
 Use `python3 zd_util.py -h` for usage instructions.
 
 This script expects that ticket directory you specify contains top-level directory names that are ticket numbers.
-For example: /users/me/tickets/
+For example:
+```
+		/users/me/tickets/
 			       |-> 12345
 			       |-> 23456
 			       |-> 19863
+```
+
 
 Prerequisites:
 

--- a/Support Automation/ZendeskTicketUtil/zd_util.py
+++ b/Support Automation/ZendeskTicketUtil/zd_util.py
@@ -1,0 +1,71 @@
+import zenpy
+import json
+import os
+import argparse
+import shutil
+
+from zenpy import Zenpy
+
+# noinspection PyTypeChecker
+parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description='''\
+Handles removal of old ZenDesk ticket directories automatically. 
+This script expects that you have a 'conf.json' file in the current directory, which stores
+a JSON block with the following format: 
+{ \"email\": \"<your-email-address>\", \"token\": \"<zendesk-api-token>\", \"subdomain\": \"streamsets\" }''')
+parser.add_argument("-f", "--force", action="store_true",
+                    help="Ignore all prompts and forcibly delete any directories without a corresponding"
+                         " ticket. Default: false.")
+parser.add_argument("-d", "--directory", default='.',
+                    help="String. Specify the path to your tickets directory, on which you want the script to run. "
+                         "Default: The current directory.")
+
+args = parser.parse_args()
+
+try:
+    with open('./creds.json', 'r') as f:
+        creds = json.load(f)
+except FileNotFoundError:
+    raise FileNotFoundError("No creds.json found in current directory. Please make sure one exists before running this"
+                            " script.")
+
+ticketNums, rmDirs = [], []
+count = 0
+caseDir = args.directory
+zenpy_client = Zenpy(**creds)
+
+print("Getting list of open Zendesk tickets...")
+for ticket in zenpy_client.search("type:ticket status:open status:new status:hold status:pending assignee:"
+                                  + creds.get("email")):
+    ticketNums.append(str(ticket.id))
+
+# next(os.walk())[1] gets a list of all top-level directories in the path specified, and will avoid any literal files
+# and/or subdirectories
+for directory in next(os.walk(caseDir))[1]:
+    if directory not in ticketNums:
+        rmDirs.append(directory)
+
+rmDirs.sort()
+
+if not args.force:
+    for item in rmDirs:
+        valid = False
+
+        while not valid:
+            confirm = input(">Delete directory: " + item + "? (Y/N) ")
+            if confirm.upper() == "Y" or confirm.upper() == "YES":
+                print("*Deleted* " + item)
+                shutil.rmtree(caseDir + "/" + item)
+                count += 1
+                valid = True
+            elif confirm.upper() == "N" or confirm.upper() == "NO":
+                print("-Skipping- " + item)
+                valid = True
+            else:
+                print("Invalid input, please specify Y or N...")
+else:
+    for item in rmDirs:
+        print("*Deleted* " + item)
+        shutil.rmtree(caseDir + "/" + item)
+        count += 1
+
+print("Removal complete. " + str(count) + " directories deleted.")


### PR DESCRIPTION
Created a tool for ZD ticket directory management on a local machine. This will remove directories which correspond to tickets that are no longer open. 

Usage and directions are included in the readme, as well as the -h/--help of the script itself.